### PR TITLE
fix: Only define compile-time interfaces (e.g., getfields, setfields) once

### DIFF
--- a/src/define_interface.jl
+++ b/src/define_interface.jl
@@ -69,7 +69,7 @@ function properties_interface(T; delegated_fields, kwargs...)
         end
         eval(output)
     end)
-    return output
+    return wrap_define_interface(T, :properties, output)
 end
 
 """
@@ -105,7 +105,7 @@ function equality_interface(T; omit::AbstractVector{Symbol}=Symbol[], equality_o
         body = :(Base.all( $equality_op( $getvalue(x, k), $getvalue(y, k) ) for k in values if k ∉ $(Expr(:tuple, QuoteNode.(omit)...))))
     end
     equality_expr = :(Base.$equality_op(x::$T, y::$T) = $equal_properties && $body)
-    return equality_expr
+    return wrap_define_interface(T, :equality, equality_expr)
 end
 
 const define_interfaces_available = (:properties, :equality, :setfields, :getfields)

--- a/src/forward_interface.jl
+++ b/src/forward_interface.jl
@@ -228,7 +228,7 @@ end
 Given `x::T`, forwards the method `\$field(x::T)` to `getfield(x, \$field)`, for each `field in fieldnames(T)`
 """
 function getfields_interface(T; omit::AbstractVector{Symbol}=Symbol[])
-    return Base.remove_linenums!(quote 
+    return wrap_define_interface(T, :getfields, Base.remove_linenums!(quote 
         local omit_fields = $(Expr(:tuple, omit...))
         local fields = fieldnames($T)
         local def_fields_expr = Expr(:block)
@@ -240,7 +240,7 @@ function getfields_interface(T; omit::AbstractVector{Symbol}=Symbol[])
         end
         eval(def_fields_expr)
         nothing
-    end)
+    end))
 end
 
 interface_at_macroexpand_time(::typeof(getfields_interface)) = false
@@ -251,7 +251,7 @@ interface_at_macroexpand_time(::typeof(getfields_interface)) = false
 Given `x::T`, forwards the method `\$field!(x::T, value)` to `setfield!(x, \$field, value)`, for each `field in fieldnames(T)`
 """
 function setfields_interface(T; omit::AbstractVector{Symbol}=Symbol[])
-    return Base.remove_linenums!(quote 
+    return wrap_define_interface(T, :setfields, Base.remove_linenums!(quote 
         local omit_fields = $(Expr(:tuple, omit...))
         local fields = fieldnames($T)
         local def_fields_expr = Expr(:block)
@@ -263,7 +263,7 @@ function setfields_interface(T; omit::AbstractVector{Symbol}=Symbol[])
         end
         eval(def_fields_expr)
         nothing
-    end)
+    end))
 end
 
 interface_at_macroexpand_time(::typeof(setfields_interface)) = false

--- a/src/util.jl
+++ b/src/util.jl
@@ -123,3 +123,9 @@ function get_kwarg(::Type{T}, kwargs, key::Symbol, default) where {T}
     value isa T || error("$key (= $value) must be a $T, got typeof($key) = $(typeof(value))")
     return value
 end
+
+has_defined_interface(T, interface) = false
+
+function wrap_define_interface(T, interface::Symbol, expr)
+    return Expr(:if, :(!(ForwardMethods.has_defined_interface($T, Val($(QuoteNode(interface)))))), Expr(:block, expr, :(ForwardMethods.has_defined_interface(::Type{$T}, ::Val{$(QuoteNode(interface))}) = true)))
+end

--- a/test/TestForwardMethods.jl
+++ b/test/TestForwardMethods.jl
@@ -72,7 +72,11 @@ module TestForwardMethods
         key2::Int 
         key3::Bool
     end
+    @test !ForwardMethods.has_defined_interface(SettableProperties, Val(:getfields))
+    @test !ForwardMethods.has_defined_interface(SettableProperties, Val(:setfields))
     @define_interface SettableProperties interface=(getfields, setfields)
+    @test ForwardMethods.has_defined_interface(SettableProperties, Val(:getfields))
+    @test ForwardMethods.has_defined_interface(SettableProperties, Val(:setfields))
 
     mutable struct CompositeProperties
         settable::SettableProperties
@@ -102,11 +106,15 @@ module TestForwardMethods
         settable::SettableProperties
         alsosettable::SettableProperties2
     end
+    @test !ForwardMethods.has_defined_interface(CompositeProperties2, Val(:properties))
+    @test !ForwardMethods.has_defined_interface(SettableProperties2, Val(:properties))
     if VERSION ≥ v"1.7"
         @define_interface CompositeProperties2 interface=properties delegated_fields=(settable, alsosettable)
     else
         @define_interface CompositeProperties2 interface=properties delegated_fields=(settable, alsosettable) is_mutable=true
     end
+    @test ForwardMethods.has_defined_interface(CompositeProperties2, Val(:properties))
+    @test !ForwardMethods.has_defined_interface(SettableProperties2, Val(:properties))
 
     struct ClashingKeys 
         key1::SettableProperties


### PR DESCRIPTION
To avoid running into issues with e.g., Revise